### PR TITLE
Support empty signatures

### DIFF
--- a/mkautodoc/__init__.py
+++ b/mkautodoc/__init__.py
@@ -1,5 +1,5 @@
 from .extension import MKAutoDocExtension, makeExtension
 
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 __all__ = ['MKAutoDocExtension', 'makeExtension']

--- a/mkautodoc/extension.py
+++ b/mkautodoc/extension.py
@@ -194,15 +194,16 @@ class AutoDocProcessor(BlockProcessor):
         bracket_elem.text = '('
         bracket_elem.set('class', 'autodoc-punctuation')
 
-        for param, is_last in last_iter(get_params(signature)):
-            param_elem = etree.SubElement(signature_elem, 'em')
-            param_elem.text = param
-            param_elem.set('class', 'autodoc-param')
+        if signature.parameters:
+            for param, is_last in last_iter(get_params(signature)):
+                param_elem = etree.SubElement(signature_elem, 'em')
+                param_elem.text = param
+                param_elem.set('class', 'autodoc-param')
 
-            if not is_last:
-                comma_elem = etree.SubElement(signature_elem, 'span')
-                comma_elem.text = ', '
-                comma_elem.set('class', 'autodoc-punctuation')
+                if not is_last:
+                    comma_elem = etree.SubElement(signature_elem, 'span')
+                    comma_elem.text = ', '
+                    comma_elem.set('class', 'autodoc-punctuation')
 
         bracket_elem = etree.SubElement(signature_elem, 'span')
         bracket_elem.text = ')'


### PR DESCRIPTION
mkautodoc currently fails with a ``StopIteration`` error when trying to render empty signatures. This PR adds a check to only try rendering parameters if the signature actually contains parameters.

I bumped the bugfix version to follow your pattern.