### PR TITLE
Upgrade pip in install script

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -8,5 +8,6 @@ else
     BIN_PATH="venv/bin/"
 fi
 
+${BIN_PATH}pip install --upgrade pip
 ${BIN_PATH}pip install -r requirements.txt
 ${BIN_PATH}pip install -e .


### PR DESCRIPTION
I wanted to try this out and found a first opportunity to contribute. :)

A small addition to the `install` script (which comes in very handy) that upgrades pip after creating the virtualenv. Prevents warnings such as:

```console
You are using pip version 19.0.3, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```