### PR TITLE
Display async keyword in front of async functions/methods

### DIFF
--- a/mkautodoc/extension.py
+++ b/mkautodoc/extension.py
@@ -182,6 +182,9 @@ class AutoDocProcessor(BlockProcessor):
         if inspect.isclass(item):
             qualifier_elem = etree.SubElement(signature_elem, "em")
             qualifier_elem.text = "class "
+        elif inspect.iscoroutinefunction(item):
+            qualifier_elem = etree.SubElement(signature_elem, "em")
+            qualifier_elem.text = "async "
 
         name_elem = etree.SubElement(signature_elem, "code")
         if module_string:

--- a/tests/mocklib/mocklib.py
+++ b/tests/mocklib/mocklib.py
@@ -24,3 +24,9 @@ class ExampleClass:
         """
         This is a property with a *docstring*.
         """
+
+
+async def example_async_function():
+    """
+    This is a coroutine function as can be seen by the *async* keyword.
+    """

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -18,6 +18,18 @@ def test_docstring():
     ]
 
 
+def test_async_function():
+    content = """
+::: mocklib.example_async_function
+"""
+    output = markdown.markdown(content, extensions=["mkautodoc"])
+    assert output.splitlines() == [
+        '<div class="autodoc">',
+        '<div class="autodoc-signature"><em>async </em><code>mocklib.<strong>example_async_function</strong></code><span class="autodoc-punctuation">(</span><span class="autodoc-punctuation">)</span></div>',
+        "</div>",
+    ]
+
+
 def test_members():
     content = """
 # Example


### PR DESCRIPTION
Prompted by https://github.com/encode/httpx/pull/464#issuecomment-541045025

Example result:

![Screenshot 2019-10-12 at 14 43 49](https://user-images.githubusercontent.com/15911462/66701683-226e9980-ecff-11e9-9f89-e80bede70220.png)
