### PR TITLE
Correct repo URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ version = get_version('mkautodoc')
 setup(
     name='mkautodoc',
     version=version,
-    url='https://github.com/encode/mkautodoc',
+    url='https://github.com/tomchristie/mkautodoc',
     license='BSD',
     description='AutoDoc for MarkDown',
     author='Tom Christie',


### PR DESCRIPTION
Technically irrelevant if the repo gets transferred to the encode org, but currently the page 404s.