### PR TITLE
Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .pytest_cache
 htmlcov
 venv
+.mypy_cache

--- a/mkautodoc/extension.py
+++ b/mkautodoc/extension.py
@@ -27,9 +27,7 @@ def import_from_string(import_str: str) -> typing.Any:
     try:
         return getattr(module, attr_str)
     except AttributeError:
-        raise ValueError(
-            f"Attribute {attr_str!r} not found in module {module_str!r}."
-        )
+        raise ValueError(f"Attribute {attr_str!r} not found in module {module_str!r}.")
 
 
 def get_params(signature: inspect.Signature) -> typing.List[str]:
@@ -118,20 +116,20 @@ def trim_docstring(docstring: typing.Optional[str]) -> str:
     # replace mentions of built-in types with links to the docs
     # on docs.python.org
     for i, x in enumerate(trimmed):
-        for t in [
-            "str", "int", "bytes", "bytearray", "list", "tuple", "range"
-        ]:
+        for t in ["str", "int", "bytes", "bytearray", "list", "tuple", "range"]:
             if t in trimmed[i]:
                 trimmed[i] = trimmed[i].replace(
                     t,
-                    "".join([
-                        "[`",
-                        t,
-                        "`](",
-                        "https://docs.python.org/3/stdtypes.html#",
-                        t,
-                        ")"
-                    ])
+                    "".join(
+                        [
+                            "[`",
+                            t,
+                            "`](",
+                            "https://docs.python.org/3/stdtypes.html#",
+                            t,
+                            ")",
+                        ]
+                    ),
                 )
 
     # Return a single string:
@@ -164,7 +162,7 @@ class AutoDocProcessor(BlockProcessor):
         m = self.RE.search(block)
 
         if m:
-            block = block[m.end():]  # removes the first line
+            block = block[m.end() :]  # removes the first line
 
         block, theRest = self.detab(block)
 
@@ -248,18 +246,13 @@ class AutoDocProcessor(BlockProcessor):
         docstring_elem.text = md.convert(docstring)
 
     def render_members(
-        self,
-        elem: etree.Element,
-        item: typing.Any,
-        members: typing.List[str] = None
+        self, elem: etree.Element, item: typing.Any, members: typing.List[str] = None
     ) -> None:
         members_elem = etree.SubElement(elem, "div")
         members_elem.set("class", "autodoc-members")
 
         if members is None:
-            members = sorted([
-                attr for attr in dir(item) if not attr.startswith("_")
-            ])
+            members = sorted([attr for attr in dir(item) if not attr.startswith("_")])
 
         info_items = []
         for attribute_name in members:


### PR DESCRIPTION
* Code cleanup
* Reformatted with black
* Replaced mentions of built-in types (e.g. `str`) in docstrings with links to the docs.
  * Example: docstring with text "The return type is str." gets turned into "The return type is [`str`](https://docs.python.org/3/stdtypes.html#str)"