### PR TITLE
WIP: Support extra markdown extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ div.autodoc-members {
   padding-left: 20px;
   margin-bottom: 15px;
 }
+
+div.autodoc-signature__long .autodoc-param-definition {
+  display: block;
+  margin-left: 20px;
+}
 ```
 
 ## Notes

--- a/mkautodoc/extension.py
+++ b/mkautodoc/extension.py
@@ -11,6 +11,9 @@ import typing
 # Fuzzy regex for determining source lines in __init__ that look like
 # attribute assignments.  Eg. `self.counter = 0`
 SET_ATTRIBUTE = re.compile("^([ \t]*)self[.]([A-Za-z0-9_]+) *=")
+SUPPORTED_MARKDOWN_EXTENSIONS = [
+    "extra",
+]
 
 
 def import_from_string(import_str: str) -> typing.Any:
@@ -267,8 +270,9 @@ class AutoDocProcessor(BlockProcessor):
     ) -> None:
         docstring_elem = etree.SubElement(elem, "div")
         docstring_elem.set("class", "autodoc-docstring")
-
-        md = Markdown(extensions=self.md.registeredExtensions)
+        md = Markdown(
+            extensions=SUPPORTED_MARKDOWN_EXTENSIONS + self.md.registeredExtensions
+        )
         docstring_elem.text = md.convert(docstring)
 
     def render_members(

--- a/mkautodoc/extension.py
+++ b/mkautodoc/extension.py
@@ -30,10 +30,10 @@ def import_from_string(import_str: str) -> typing.Any:
         raise ValueError(f"Attribute {attr_str!r} not found in module {module_str!r}.")
 
 
-def get_params(signature: inspect.Signature) -> typing.List[str]:
+def render_params(signature: inspect.Signature) -> typing.List[etree.Element]:
     """
-    Given a function signature, return a list of parameter strings
-    to use in documentation.
+    Given a function signature, return a list of parameters rendered to
+    etree elements, for use in documentation.
 
     Eg. test(a, b=None, **kwargs) -> ['a', 'b=None', '**kwargs']
     """
@@ -42,24 +42,47 @@ def get_params(signature: inspect.Signature) -> typing.List[str]:
     render_kw_only_separator = True
 
     for parameter in signature.parameters.values():
-        value = parameter.name
-        if parameter.default is not parameter.empty:
-            value = f"{value}={parameter.default!r}"
+        param = etree.Element("span", {"class": "autodoc-param-definition"})
 
+        value = parameter.name
         if parameter.kind is parameter.VAR_POSITIONAL:
             render_kw_only_separator = False
             value = f"*{value}"
         elif parameter.kind is parameter.VAR_KEYWORD:
             value = f"**{value}"
+        param_name = etree.SubElement(
+            param, "em", {"class": "autodoc-param autodoc-param-name"}
+        )
+        param_name.text = value
+
+        if parameter.annotation is not parameter.empty:
+            colon = etree.SubElement(param, "span", {"class": "autodoc-punctuation"})
+            colon.text = ": "
+            type = etree.SubElement(param, "span", {"class": "autodoc-type-annotation"})
+            type.text = inspect.formatannotation(parameter.annotation)
+        if parameter.default is not parameter.empty:
+            equals = etree.SubElement(param, "span", {"class": "autodoc-punctuation"})
+            equals.text = "="
+            default = etree.SubElement(
+                param, "span", {"class": "autodoc-param-default"}
+            )
+            default.text = f"{parameter.default!r}"
+
         elif parameter.kind is parameter.POSITIONAL_ONLY:
             if render_pos_only_separator:
                 render_pos_only_separator = False
-                params.append("/")
+                pos_seperator = etree.SubElement(
+                    param, "span", {"class": "autodoc-punctuation"}
+                )
+                pos_seperator.text = "/"
         elif parameter.kind is parameter.KEYWORD_ONLY:
             if render_kw_only_separator:
                 render_kw_only_separator = False
-                params.append("*")
-        params.append(value)
+                kw_separator = etree.SubElement(
+                    param, "span", {"class": "autodoc-punctuation"}
+                )
+                kw_separator.text = "*"
+        params.append(param)
 
     return params
 
@@ -182,9 +205,11 @@ class AutoDocProcessor(BlockProcessor):
         if inspect.isclass(item):
             qualifier_elem = etree.SubElement(signature_elem, "em")
             qualifier_elem.text = "class "
+            qualifier_elem.set("class", "autodoc-qualifier")
         elif inspect.iscoroutinefunction(item):
             qualifier_elem = etree.SubElement(signature_elem, "em")
             qualifier_elem.text = "async "
+            qualifier_elem.set("class", "autodoc-qualifier")
 
         name_elem = etree.SubElement(signature_elem, "code")
         if module_string:
@@ -204,19 +229,38 @@ class AutoDocProcessor(BlockProcessor):
         bracket_elem.set("class", "autodoc-punctuation")
 
         if signature.parameters:
-            for param, is_last in last_iter(get_params(signature)):
-                param_elem = etree.SubElement(signature_elem, "em")
-                param_elem.text = param
-                param_elem.set("class", "autodoc-param")
-
+            for param_elem, is_last in last_iter(render_params(signature)):
+                signature_elem.append(param_elem)
                 if not is_last:
-                    comma_elem = etree.SubElement(signature_elem, "span")
+                    comma_elem = etree.SubElement(param_elem, "span")
                     comma_elem.text = ", "
                     comma_elem.set("class", "autodoc-punctuation")
 
         bracket_elem = etree.SubElement(signature_elem, "span")
         bracket_elem.text = ")"
         bracket_elem.set("class", "autodoc-punctuation")
+
+        return_annotated = (
+            signature.return_annotation is not signature.empty
+            and
+            # covers return-type of class signatures:
+            signature.return_annotation is not None
+        )
+        if return_annotated:
+            arrow = etree.SubElement(
+                signature_elem, "span", {"class": "autdoc-punctuation"}
+            )
+            arrow.text = " -> "
+            signature_type = etree.SubElement(
+                signature_elem, "span", {"class": "autodoc-type-annotation"}
+            )
+            signature_type.text = inspect.formatannotation(signature.return_annotation)
+
+        rendered_signature_text = "".join(signature_elem.itertext())
+        if len(rendered_signature_text) > 88:
+            signature_elem.set(
+                "class", signature_elem.attrib["class"] + " autodoc-signature__long"
+            )
 
     def render_docstring(
         self, elem: etree.Element, item: typing.Any, docstring: str

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -4,12 +4,13 @@ import textwrap
 
 
 def tostring(xml_string):
-    """ Wraps `xml_string` in a div so it can be rendered,
-        even if it has multiple roots"""
+    """
+    Wraps `xml_string` in a div so it can be rendered, even if it has multiple roots.
+    """
     return remove_indents(f"<div>{remove_indents(xml_string)}</div>").encode("utf-8")
 
 
-def to_readible_error_output(xml_string):
+def to_readable_error_output(xml_string):
     return textwrap.dedent(
         "\n".join(
             minidom.parseString(tostring(xml_string))
@@ -20,23 +21,26 @@ def to_readible_error_output(xml_string):
 
 
 def remove_indents(html):
-    """ Remove leading whitespace from a string
+    """
+    Remove leading whitespace from a string
 
-        e.g.
-            input:                    output:
-            . <div>                   . <div>
-            .    <p>Some Text</p>     . <p>Some Text</p>
-            .    <div>                . <div>
-            .      Some more text     . Some more text
-            .    </div>               . </div>
-            . </div>                  . </div>
+    e.g.
+        input:                    output:
+        . <div>                   . <div>
+        .    <p>Some Text</p>     . <p>Some Text</p>
+        .    <div>                . <div>
+        .      Some more text     . Some more text
+        .    </div>               . </div>
+        . </div>                  . </div>
     """
     lines = [el.lstrip() for el in html.split("\n")]
     return "".join([el for el in lines if el or el != "\n"])
 
 
 def assert_elements_equal(element, reference_element):
-    """  Assert, recursively, the equality of two etree objects. """
+    """
+    Assert, recursively, the equality of two etree objects.
+    """
     assert (
         element.text == reference_element.text
     ), f"Text doesn't match: {element.text} =/= {reference_element.text}."
@@ -54,7 +58,7 @@ def assert_xml_equal(xml_string, expected_xml_string):
     # this prints a human-formatted string of what the test passed in -- useful
     # if you need to modify test expectations after you've modified
     # a rendering and tested it visually
-    print(to_readible_error_output(xml_string))
+    print(to_readable_error_output(xml_string))
 
     assert_elements_equal(
         etree.ElementTree.fromstring(tostring(xml_string)),

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,0 +1,62 @@
+from xml import etree
+from xml.dom import minidom
+import textwrap
+
+
+def tostring(xml_string):
+    """ Wraps `xml_string` in a div so it can be rendered,
+        even if it has multiple roots"""
+    return remove_indents(f"<div>{remove_indents(xml_string)}</div>").encode("utf-8")
+
+
+def to_readible_error_output(xml_string):
+    return textwrap.dedent(
+        "\n".join(
+            minidom.parseString(tostring(xml_string))
+            .toprettyxml(indent="  ")
+            .split("\n")[2:-2]  # remove xml declaration and div added by `tostring`
+        )
+    )  # dent by "  "
+
+
+def remove_indents(html):
+    """ Remove leading whitespace from a string
+
+        e.g.
+            input:                    output:
+            . <div>                   . <div>
+            .    <p>Some Text</p>     . <p>Some Text</p>
+            .    <div>                . <div>
+            .      Some more text     . Some more text
+            .    </div>               . </div>
+            . </div>                  . </div>
+    """
+    lines = [el.lstrip() for el in html.split("\n")]
+    return "".join([el for el in lines if el or el != "\n"])
+
+
+def assert_elements_equal(element, reference_element):
+    """  Assert, recursively, the equality of two etree objects. """
+    assert (
+        element.text == reference_element.text
+    ), f"Text doesn't match: {element.text} =/= {reference_element.text}."
+    assert (
+        element.attrib == reference_element.attrib
+    ), f"Attrib doesn't match: {element.attrib} =/= {reference_element.attrib}"
+    assert len(element) == len(
+        reference_element
+    ), f"Expected {len(reference_element)} children but got {len(element)}"
+    for sub_element, reference_sub_element in zip(element, reference_element):
+        assert_elements_equal(sub_element, reference_sub_element)
+
+
+def assert_xml_equal(xml_string, expected_xml_string):
+    # this prints a human-formatted string of what the test passed in -- useful
+    # if you need to modify test expectations after you've modified
+    # a rendering and tested it visually
+    print(to_readible_error_output(xml_string))
+
+    assert_elements_equal(
+        etree.ElementTree.fromstring(tostring(xml_string)),
+        etree.ElementTree.fromstring(tostring(expected_xml_string)),
+    )

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -3,6 +3,40 @@ from xml.dom import minidom
 import textwrap
 
 
+def assert_xml_equal(xml_string, expected_xml_string):
+    """
+    Assert equality of two xml strings, particularly that the contents of
+    each string have the same elements, with the same attributes (e.g. class,
+    text) and the same non-xml string contents
+    """
+    # this prints a human-formatted string of what the test passed in -- useful
+    # if you need to modify test expectations after you've modified
+    # a rendering and tested it visually
+    print(to_readable_error_output(xml_string))
+
+    assert_elements_equal(
+        etree.ElementTree.fromstring(tostring(xml_string)),
+        etree.ElementTree.fromstring(tostring(expected_xml_string)),
+    )
+
+
+def assert_elements_equal(element, reference_element):
+    """
+    Assert, recursively, the equality of two etree objects.
+    """
+    assert (
+        element.text == reference_element.text
+    ), f"Text doesn't match: {element.text} =/= {reference_element.text}."
+    assert (
+        element.attrib == reference_element.attrib
+    ), f"Attrib doesn't match: {element.attrib} =/= {reference_element.attrib}"
+    assert len(element) == len(
+        reference_element
+    ), f"Expected {len(reference_element)} children but got {len(element)}"
+    for sub_element, reference_sub_element in zip(element, reference_element):
+        assert_elements_equal(sub_element, reference_sub_element)
+
+
 def tostring(xml_string):
     """
     Wraps `xml_string` in a div so it can be rendered, even if it has multiple roots.
@@ -35,32 +69,3 @@ def remove_indents(html):
     """
     lines = [el.lstrip() for el in html.split("\n")]
     return "".join([el for el in lines if el or el != "\n"])
-
-
-def assert_elements_equal(element, reference_element):
-    """
-    Assert, recursively, the equality of two etree objects.
-    """
-    assert (
-        element.text == reference_element.text
-    ), f"Text doesn't match: {element.text} =/= {reference_element.text}."
-    assert (
-        element.attrib == reference_element.attrib
-    ), f"Attrib doesn't match: {element.attrib} =/= {reference_element.attrib}"
-    assert len(element) == len(
-        reference_element
-    ), f"Expected {len(reference_element)} children but got {len(element)}"
-    for sub_element, reference_sub_element in zip(element, reference_element):
-        assert_elements_equal(sub_element, reference_sub_element)
-
-
-def assert_xml_equal(xml_string, expected_xml_string):
-    # this prints a human-formatted string of what the test passed in -- useful
-    # if you need to modify test expectations after you've modified
-    # a rendering and tested it visually
-    print(to_readable_error_output(xml_string))
-
-    assert_elements_equal(
-        etree.ElementTree.fromstring(tostring(xml_string)),
-        etree.ElementTree.fromstring(tostring(expected_xml_string)),
-    )

--- a/tests/mocklib/mocklib.py
+++ b/tests/mocklib/mocklib.py
@@ -7,6 +7,16 @@ def example_function(a, b=None, *args, **kwargs):
     """
 
 
+def function_with_table():
+    """
+    I have markdown tables
+
+    | Such | As |
+    | ---- | -- |
+    | this | one |
+    """
+
+
 def annotated_function(
     a: int, b: List[Dict[str, float]] = None, *args, **kwargs
 ) -> bool:

--- a/tests/mocklib/mocklib.py
+++ b/tests/mocklib/mocklib.py
@@ -1,6 +1,17 @@
+from typing import Dict, List
+
+
 def example_function(a, b=None, *args, **kwargs):
     """
     This is a function with a *docstring*.
+    """
+
+
+def annotated_function(
+    a: int, b: List[Dict[str, float]] = None, *args, **kwargs
+) -> bool:
+    """
+    This function has annotations.
     """
 
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -12,7 +12,7 @@ def test_annotated_function():
     output = markdown.markdown(content, extensions=["mkautodoc"])
     assert_xml_equal(
         output,
-        """\
+        """
 <h1>Example</h1>
 <div class="autodoc">
   <div class="autodoc-signature autodoc-signature__long">

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,53 @@
+import markdown
+from .assertions import assert_xml_equal
+
+
+def test_annotated_function():
+    content = """
+# Example
+
+::: mocklib.annotated_function
+    :docstring:
+"""
+    output = markdown.markdown(content, extensions=["mkautodoc"])
+    assert_xml_equal(
+        output,
+        """\
+<h1>Example</h1>
+<div class="autodoc">
+  <div class="autodoc-signature autodoc-signature__long">
+    <code>
+      mocklib.
+      <strong>annotated_function</strong>
+    </code>
+    <span class="autodoc-punctuation">(</span>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">a</em>
+      <span class="autodoc-punctuation">: </span>
+      <span class="autodoc-type-annotation">int</span>
+      <span class="autodoc-punctuation">, </span>
+    </span>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">b</em>
+      <span class="autodoc-punctuation">: </span>
+      <span class="autodoc-type-annotation">List[Dict[str, float]]</span>
+      <span class="autodoc-punctuation">=</span>
+      <span class="autodoc-param-default">None</span>
+      <span class="autodoc-punctuation">, </span>
+    </span>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">*args</em>
+      <span class="autodoc-punctuation">, </span>
+    </span>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">**kwargs</em>
+    </span>
+    <span class="autodoc-punctuation">)</span>
+    <span class="autdoc-punctuation"> -&gt; </span>
+    <span class="autodoc-type-annotation">bool</span>
+  </div>
+  <div class="autodoc-docstring">
+    <p>This function has annotations.</p>
+  </div>
+</div>""",
+    )

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,4 +1,5 @@
 import markdown
+from .assertions import assert_xml_equal
 
 
 def test_docstring():
@@ -9,13 +10,33 @@ def test_docstring():
     :docstring:
 """
     output = markdown.markdown(content, extensions=["mkautodoc"])
-    assert output.splitlines() == [
-        "<h1>Example</h1>",
-        '<div class="autodoc">',
-        '<div class="autodoc-signature"><code>mocklib.<strong>example_function</strong></code><span class="autodoc-punctuation">(</span><em class="autodoc-param">a</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">b=None</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">*args</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">**kwargs</em><span class="autodoc-punctuation">)</span></div>',
-        '<div class="autodoc-docstring"><p>This is a function with a <em>docstring</em>.</p></div>',
-        "</div>",
-    ]
+    assert_xml_equal(
+        output,
+        """\
+<h1>Example</h1>
+<div class="autodoc">
+  <div class="autodoc-signature">
+    <code>
+      mocklib.
+      <strong>example_function</strong>
+    </code>
+    <span class="autodoc-punctuation">(</span>
+    <em class="autodoc-param">a</em>
+    <span class="autodoc-punctuation">, </span>
+    <em class="autodoc-param">b=None</em>
+    <span class="autodoc-punctuation">, </span>
+    <em class="autodoc-param">*args</em>
+    <span class="autodoc-punctuation">, </span>
+    <em class="autodoc-param">**kwargs</em>
+    <span class="autodoc-punctuation">)</span>
+  </div>
+  <div class="autodoc-docstring">
+    <p>
+      This is a function with a <em>docstring</em>.
+    </p>
+  </div>
+</div>""",
+    )
 
 
 def test_async_function():
@@ -23,11 +44,21 @@ def test_async_function():
 ::: mocklib.example_async_function
 """
     output = markdown.markdown(content, extensions=["mkautodoc"])
-    assert output.splitlines() == [
-        '<div class="autodoc">',
-        '<div class="autodoc-signature"><em>async </em><code>mocklib.<strong>example_async_function</strong></code><span class="autodoc-punctuation">(</span><span class="autodoc-punctuation">)</span></div>',
-        "</div>",
-    ]
+    assert_xml_equal(
+        output,
+        """\
+<div class="autodoc">
+  <div class="autodoc-signature">
+    <em>async </em>
+    <code>
+      mocklib.
+      <strong>example_async_function</strong>
+    </code>
+    <span class="autodoc-punctuation">(</span>
+    <span class="autodoc-punctuation">)</span>
+  </div>
+</div>""",
+    )
 
 
 def test_members():
@@ -39,16 +70,53 @@ def test_members():
     :members:
 """
     output = markdown.markdown(content, extensions=["mkautodoc"])
-    assert output.splitlines() == [
-        "<h1>Example</h1>",
-        '<div class="autodoc">',
-        '<div class="autodoc-signature"><em>class </em><code>mocklib.<strong>ExampleClass</strong></code><span class="autodoc-punctuation">(</span><span class="autodoc-punctuation">)</span></div>',
-        '<div class="autodoc-docstring"><p>This is a class with a <em>docstring</em>.</p></div>',
-        '<div class="autodoc-members">',
-        '<div class="autodoc-signature"><code><strong>example_method</strong></code><span class="autodoc-punctuation">(</span><em class="autodoc-param">self</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">a</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">b=None</em><span class="autodoc-punctuation">)</span></div>',
-        '<div class="autodoc-docstring"><p>This is a method with a <em>docstring</em>.</p></div>',
-        '<div class="autodoc-signature"><code><strong>example_property</strong></code></div>',
-        '<div class="autodoc-docstring"><p>This is a property with a <em>docstring</em>.</p></div>',
-        "</div>",
-        "</div>",
-    ]
+    assert_xml_equal(
+        output,
+        """\
+<h1>Example</h1>
+<div class="autodoc">
+  <div class="autodoc-signature">
+    <em>class </em>
+    <code>
+      mocklib.
+      <strong>ExampleClass</strong>
+    </code>
+    <span class="autodoc-punctuation">(</span>
+    <span class="autodoc-punctuation">)</span>
+  </div>
+  <div class="autodoc-docstring">
+    <p>
+      This is a class with a <em>docstring</em>.
+    </p>
+  </div>
+  <div class="autodoc-members">
+    <div class="autodoc-signature">
+      <code>
+        <strong>example_method</strong>
+      </code>
+      <span class="autodoc-punctuation">(</span>
+      <em class="autodoc-param">self</em>
+      <span class="autodoc-punctuation">, </span>
+      <em class="autodoc-param">a</em>
+      <span class="autodoc-punctuation">, </span>
+      <em class="autodoc-param">b=None</em>
+      <span class="autodoc-punctuation">)</span>
+    </div>
+    <div class="autodoc-docstring">
+      <p>
+        This is a method with a <em>docstring</em>.
+      </p>
+    </div>
+    <div class="autodoc-signature">
+      <code>
+        <strong>example_property</strong>
+      </code>
+    </div>
+    <div class="autodoc-docstring">
+      <p>
+        This is a property with a <em>docstring</em>.
+      </p>
+    </div>
+  </div>
+</div>""",
+    )

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -21,13 +21,23 @@ def test_docstring():
       <strong>example_function</strong>
     </code>
     <span class="autodoc-punctuation">(</span>
-    <em class="autodoc-param">a</em>
-    <span class="autodoc-punctuation">, </span>
-    <em class="autodoc-param">b=None</em>
-    <span class="autodoc-punctuation">, </span>
-    <em class="autodoc-param">*args</em>
-    <span class="autodoc-punctuation">, </span>
-    <em class="autodoc-param">**kwargs</em>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">a</em>
+      <span class="autodoc-punctuation">, </span>
+    </span>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">b</em>
+      <span class="autodoc-punctuation">=</span>
+      <span class="autodoc-param-default">None</span>
+      <span class="autodoc-punctuation">, </span>
+    </span>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">*args</em>
+      <span class="autodoc-punctuation">, </span>
+    </span>
+    <span class="autodoc-param-definition">
+      <em class="autodoc-param autodoc-param-name">**kwargs</em>
+    </span>
     <span class="autodoc-punctuation">)</span>
   </div>
   <div class="autodoc-docstring">
@@ -49,7 +59,7 @@ def test_async_function():
         """\
 <div class="autodoc">
   <div class="autodoc-signature">
-    <em>async </em>
+    <em class="autodoc-qualifier">async </em>
     <code>
       mocklib.
       <strong>example_async_function</strong>
@@ -76,7 +86,7 @@ def test_members():
 <h1>Example</h1>
 <div class="autodoc">
   <div class="autodoc-signature">
-    <em>class </em>
+    <em class="autodoc-qualifier">class </em>
     <code>
       mocklib.
       <strong>ExampleClass</strong>
@@ -95,11 +105,19 @@ def test_members():
         <strong>example_method</strong>
       </code>
       <span class="autodoc-punctuation">(</span>
-      <em class="autodoc-param">self</em>
-      <span class="autodoc-punctuation">, </span>
-      <em class="autodoc-param">a</em>
-      <span class="autodoc-punctuation">, </span>
-      <em class="autodoc-param">b=None</em>
+      <span class="autodoc-param-definition">
+        <em class="autodoc-param autodoc-param-name">self</em>
+        <span class="autodoc-punctuation">, </span>
+      </span>
+      <span class="autodoc-param-definition">
+        <em class="autodoc-param autodoc-param-name">a</em>
+        <span class="autodoc-punctuation">, </span>
+      </span>
+      <span class="autodoc-param-definition">
+        <em class="autodoc-param autodoc-param-name">b</em>
+        <span class="autodoc-punctuation">=</span>
+        <span class="autodoc-param-default">None</span>
+      </span>
       <span class="autodoc-punctuation">)</span>
     </div>
     <div class="autodoc-docstring">

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -12,7 +12,7 @@ def test_docstring():
     output = markdown.markdown(content, extensions=["mkautodoc"])
     assert_xml_equal(
         output,
-        """\
+        """
 <h1>Example</h1>
 <div class="autodoc">
   <div class="autodoc-signature">
@@ -56,7 +56,7 @@ def test_async_function():
     output = markdown.markdown(content, extensions=["mkautodoc"])
     assert_xml_equal(
         output,
-        """\
+        """
 <div class="autodoc">
   <div class="autodoc-signature">
     <em class="autodoc-qualifier">async </em>
@@ -82,7 +82,7 @@ def test_members():
     output = markdown.markdown(content, extensions=["mkautodoc"])
     assert_xml_equal(
         output,
-        """\
+        """
 <h1>Example</h1>
 <div class="autodoc">
   <div class="autodoc-signature">

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -138,3 +138,48 @@ def test_members():
   </div>
 </div>""",
     )
+
+
+def test_extra_extentions_are_supported():
+    """
+    Tests support for 'extra' extensions as supported by
+    the markdown package https://python-markdown.github.io/extensions/extra/
+    """
+    content = """
+
+# Example
+::: mocklib.function_with_table
+    :docstring:
+    """
+    output = markdown.markdown(content, extensions=["mkautodoc"])
+    assert_xml_equal(
+        output,
+        """
+<div class="autodoc">
+  <div class="autodoc-signature">
+    <code>
+      mocklib.
+      <strong>function_with_table</strong>
+    </code>
+    <span class="autodoc-punctuation">(</span>
+    <span class="autodoc-punctuation">)</span>
+  </div>
+  <div class="autodoc-docstring">
+    <p>I have markdown tables</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Such</th>
+          <th>As</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>this</td>
+          <td>one</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>""",
+    )


### PR DESCRIPTION
Adds the `extra` extensions listed on the `markdown` package docs

For example, here is a docstring with a table, definition list, and python code-block:

```
class CimNetwork:
    """
     Dict-like collection of cim objects
 
     SafeIds
     :   For all the things i said
 
     dict
    :   doing stuff insn't hard 
    
     | So | Far |
     | -- | --- |
     | table | stuff |
 
     ```python
     network = CimNetwork({
         "_id_1": cim.ACLineSegment(UUID="_id_1"),
         "_id_2": cim.Terminal(UUID="_id_2"),
     })
     ```
     """
```

This renders like this:
![image](https://user-images.githubusercontent.com/2414360/75645954-fc965280-5c15-11ea-9e30-65d2672a537e.png)


Addresses https://github.com/tomchristie/mkautodoc/issues/14
Depends on merging https://github.com/tomchristie/mkautodoc/pull/13, since it contains test refactoring that is used by this MR