### PR TITLE
Add a blacklist option for member attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,14 @@ May optionally accept a list of member attributes that should be documented. For
     :docstring:
     :members: currency vat_registered calculate_expenses
 ```
+
+#### The `:members-exclude:` declaration.
+
+Renders documentation identically to `:members:`, but removes any member attributes that are listed.
+For example:
+
+```markdown
+::: my_library.SomeClass
+    :docstring:
+    :members-exclude: currency
+```

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -52,3 +52,25 @@ def test_members():
         "</div>",
         "</div>",
     ]
+
+
+def test_members_exclude():
+    content = """
+# Example
+
+::: mocklib.ExampleClass
+    :docstring:
+    :members-exclude: example_property
+"""
+    output = markdown.markdown(content, extensions=["mkautodoc"])
+    assert output.splitlines() == [
+        "<h1>Example</h1>",
+        '<div class="autodoc">',
+        '<div class="autodoc-signature"><em>class </em><code>mocklib.<strong>ExampleClass</strong></code><span class="autodoc-punctuation">(</span><span class="autodoc-punctuation">)</span></div>',
+        '<div class="autodoc-docstring"><p>This is a class with a <em>docstring</em>.</p></div>',
+        '<div class="autodoc-members">',
+        '<div class="autodoc-signature"><code><strong>example_method</strong></code><span class="autodoc-punctuation">(</span><em class="autodoc-param">self</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">a</em><span class="autodoc-punctuation">, </span><em class="autodoc-param">b=None</em><span class="autodoc-punctuation">)</span></div>',
+        '<div class="autodoc-docstring"><p>This is a method with a <em>docstring</em>.</p></div>',
+        "</div>",
+        "</div>",
+    ]


### PR DESCRIPTION
I found that it would be very useful to have a blacklist option for `:members:`, instead of the current whitelist option. I've added an extra command `:members-exclude:` that renders identically to `:members:`, but excludes any listed attributes

Example usage:
```
::: mocklib.ExampleClass
    :docstring:
    :members-exclude: example_property
```