### PR TITLE
Address deprecation of markdown.util.etree

### DIFF
--- a/mkautodoc/extension.py
+++ b/mkautodoc/extension.py
@@ -1,7 +1,7 @@
 from markdown import Markdown
 from markdown.extensions import Extension
 from markdown.blockprocessors import BlockProcessor
-from markdown.util import etree
+from xml.etree import ElementTree as etree
 import importlib
 import inspect
 import re


### PR DESCRIPTION
Refs https://github.com/encode/httpx/pull/2313

https://python-markdown.github.io/change_log/release-3.4/

```console
Python 3.10.0 (default, Nov 28 2021, 23:05:33) [GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import mkautodoc
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/florimond/dev/fairness/httpx/venv/lib/python3.10/site-packages/mkautodoc/__init__.py", line 1, in <module>
    from .extension import MKAutoDocExtension, makeExtension
  File "/home/florimond/dev/fairness/httpx/venv/lib/python3.10/site-packages/mkautodoc/extension.py", line 4, in <module>
    from markdown.util import etree
ImportError: cannot import name 'etree' from 'markdown.util' (/home/florimond/dev/fairness/httpx/venv/lib/python3.10/site-packages/markdown/util.py)
>>> 
```

https://python-markdown.github.io/change_log/release-3.4/

> Previously deprecated objects have been removed
>
> Deprecated Object | Replacement Object
> -- | --
> markdown.util.etree | xml.etree.ElementTree
