### PR TITLE
add install hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This markdown extension adds `autodoc` style support, for use with MkDocs.
 
 ![aIAgAAjQpG](https://user-images.githubusercontent.com/647359/66651320-a276ff80-ec2a-11e9-9cec-9eba425d5304.gif)
 
+## Install
+
+The usual way:
+
+```bash
+pip install mkautodoc
+```
+
 ## Usage
 
 #### 1. Include the extension in you `mkdocs.yml` config file:


### PR DESCRIPTION
It may be superfluous to add an install hint, but there are other packages on pypi (mkautodocs, mkdocs_autodoc) that could be misinterpreted as this one. Better be clear.